### PR TITLE
Fix off-by-one error due to float arithmetic

### DIFF
--- a/data/mini-mempool.json
+++ b/data/mini-mempool.json
@@ -192,5 +192,31 @@
     "spentby": [
     ],
     "bip125-replaceable": false
+  },
+  "88b75cf4ef99814d1f3f2245800b93aa400e92cfeae763f1334f3059232204a7": {
+    "fees": {
+      "base": 0.00013120,
+      "modified": 0.00013120,
+      "ancestor": 0.00013120,
+      "descendant": 0.00013120
+    },
+    "vsize": 164,
+    "weight": 653,
+    "fee": 0.00013120,
+    "modifiedfee": 0.00013120,
+    "time": 1588882844,
+    "height": 629405,
+    "descendantcount": 1,
+    "descendantsize": 164,
+    "descendantfees": 13120,
+    "ancestorcount": 1,
+    "ancestorsize": 164,
+    "ancestorfees": 13120,
+    "wtxid": "d2912866d67aa85af580e01494cc4615010acb48f2478c073b83642467336e94",
+    "depends": [
+    ],
+    "spentby": [
+    ],
+    "bip125-replaceable": false
   }
 }

--- a/mempool.py
+++ b/mempool.py
@@ -1,6 +1,7 @@
 import heapq
 import json
 import math
+import decimal
 from pathlib import Path
 import logging
 
@@ -23,12 +24,12 @@ class Mempool():
         txsJSON = {}
         with open(filePath, 'r') as import_file:
             self.blockId = Path(filePath).stem
-            txsJSON = json.load(import_file)
+            txsJSON = json.load(import_file, parse_float=decimal.Decimal)
 
             for txid in txsJSON.keys():
                 tx = Transaction(
                     txid,
-                    txsJSON[txid]["fee"] * math.pow(10,8),
+                    txsJSON[txid]["fee"].shift(8),
                     txsJSON[txid]["weight"],
                     txsJSON[txid]["depends"],
                     txsJSON[txid]["spentby"]

--- a/test_mempool.py
+++ b/test_mempool.py
@@ -25,10 +25,12 @@ class TestMempool(unittest.TestCase):
         for txid in txids:
             self.assertEqual(True, txid in keys)
 
-    def test_parse_from_JSON(self):
+    def get_mempool_json(self):
         mempool = Mempool()
-        print("Start parsing mempool file")
         mempool.fromJSON("data/mini-mempool.json")
+        return mempool
+
+    def test_parse_from_JSON(self):
         expectedTxids = [
             "01123eb3ec64c381ce29b98aa71a5998094054171c5b9a9e0f0084289ad2ccf6",
             "a5823eb3ec64c381ce29b98aa71a5998094054171c5b9a9e0f0084289ad2ccf6",
@@ -41,9 +43,17 @@ class TestMempool(unittest.TestCase):
         ]
         expectedTxids.sort()
 
+        mempool = self.get_mempool_json()
         txids = list(mempool.getTxs().keys())
         txids.sort()
         self.assertEqual(expectedTxids, txids)
+
+    def test_mempool_fee(self):
+        txs = self.get_mempool_json().getTxs()
+        self.assertEqual(
+            13120,
+            txs["88b75cf4ef99814d1f3f2245800b93aa400e92cfeae763f1334f3059232204a7"].fee
+        )
 
     def test_drop_tx(self):
         mempool = Mempool()

--- a/test_mempool.py
+++ b/test_mempool.py
@@ -29,17 +29,21 @@ class TestMempool(unittest.TestCase):
         mempool = Mempool()
         print("Start parsing mempool file")
         mempool.fromJSON("data/mini-mempool.json")
-        txids = [
+        expectedTxids = [
+            "01123eb3ec64c381ce29b98aa71a5998094054171c5b9a9e0f0084289ad2ccf6",
             "a5823eb3ec64c381ce29b98aa71a5998094054171c5b9a9e0f0084289ad2ccf6",
             "b5823eb3ec64c381ce29b98aa71a5998094054171c5b9a9e0f0084289ad2ccf6",
             "9a9b73b2a6ea86a495662d5e90cda9fadbf70c470231dff6b4f9286707f30812",
             "154ff366005101ed97c044782d82e3abf44073968bd0db21c9f5b27296aa3de2",
-            "6a2ba899956359eb278f6daffc8ae0f5dfb631a67dbfe57687f665b20bcf063e"
+            "6a2ba899956359eb278f6daffc8ae0f5dfb631a67dbfe57687f665b20bcf063e",
+            "88b75cf4ef99814d1f3f2245800b93aa400e92cfeae763f1334f3059232204a7",
+            "8a2ba899956359eb278f6daffc8ae0f5dfb631a67dbfe57687f665b20bcf063e"
         ]
+        expectedTxids.sort()
 
-        keys = mempool.getTxs().keys()
-        for txid in txids:
-            self.assertEqual(True, txid in keys)
+        txids = list(mempool.getTxs().keys())
+        txids.sort()
+        self.assertEqual(expectedTxids, txids)
 
     def test_drop_tx(self):
         mempool = Mempool()


### PR DESCRIPTION
By default, `json.load` uses float which can lead to imprecision when converting from BTC to sats. 